### PR TITLE
Add OpenAPI endpoint to server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "mongodb": "^5.0.0"
+    "mongodb": "^5.0.0",
+    "swagger-ui-express": "^4.1.6",
+    "swagger-jsdoc": "^6.1.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const { MongoClient, ServerApiVersion, ObjectId } = require('mongodb');
 const cors = require('cors');
 require('dotenv').config();
+const swaggerUi = require('swagger-ui-express');
+const swaggerJsdoc = require('swagger-jsdoc');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -9,6 +11,26 @@ const PORT = process.env.PORT || 3000;
 // Middleware
 app.use(cors());
 app.use(express.json());
+
+const swaggerOptions = {
+    swaggerDefinition: {
+        openapi: '3.0.0',
+        info: {
+            title: 'Clipper API',
+            version: '1.0.0',
+            description: 'API documentation for Clipper application',
+        },
+        servers: [
+            {
+                url: `http://localhost:${PORT}`,
+            },
+        ],
+    },
+    apis: ['./server.js'],
+};
+
+const swaggerDocs = swaggerJsdoc(swaggerOptions);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 
 // MongoDB Connection URI
 const uri = process.env.MONGODB_URI;


### PR DESCRIPTION
Add OpenAPI documentation to the Clipper application.

* **server.js**
  - Import `swaggerUi` and `swaggerJsdoc` packages.
  - Define `swaggerOptions` object with OpenAPI configuration.
  - Create `swaggerDocs` using `swaggerJsdoc` with `swaggerOptions`.
  - Add `/api-docs` route to serve OpenAPI documentation using `swaggerUi`.

* **package.json**
  - Add `swagger-ui-express` and `swagger-jsdoc` to dependencies.

